### PR TITLE
Bugfix: Renpho CSV Import Crash

### DIFF
--- a/app/src/main/kotlin/paufregi/garminfeed/presentation/syncweight/SyncWeightActivity.kt
+++ b/app/src/main/kotlin/paufregi/garminfeed/presentation/syncweight/SyncWeightActivity.kt
@@ -9,8 +9,10 @@ import androidx.activity.viewModels
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dagger.hilt.android.AndroidEntryPoint
 import paufregi.garminfeed.presentation.ui.theme.Theme
 
+@AndroidEntryPoint
 @ExperimentalMaterial3Api
 class SyncWeightActivity : ComponentActivity() {
 

--- a/app/src/main/kotlin/paufregi/garminfeed/presentation/syncweight/SyncWeightModelView.kt
+++ b/app/src/main/kotlin/paufregi/garminfeed/presentation/syncweight/SyncWeightModelView.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SyncWeightModelView @Inject constructor(
-    private val syncWeightUseCase: SyncWeightUseCase
+    val syncWeightUseCase: SyncWeightUseCase
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<SyncWeightState>(SyncWeightState.Idle)


### PR DESCRIPTION
### Bugfix: Renpho CSV Import Crash

This PR addresses a critical bug that caused the app to crash when attempting to import a CSV file from Renpho.

The root cause of the issue was incorrect Hilt dependency injection in the `SyncWeightActivity`. The `SyncWeightModelView` was not being initialized properly, leading to a NullPointerException.

This PR resolves the issue by:
- Correcting the Hilt configuration in SyncWeightActivity
- Ensuring the SyncWeightModelView is injected correctly